### PR TITLE
Add Javascript validation and show category suggestions

### DIFF
--- a/enhancement.js
+++ b/enhancement.js
@@ -1,0 +1,77 @@
+$( function() {
+	var $from = $( '#fromLang' ),
+		$to = $( '#toLang' ),
+		$category = $( '#category' ),
+		$submit = $( 'button[type="submit"]' ),
+		isValid = function () {
+			return (
+				!!$from.val() &&
+				!!$to.val() &&
+				!!$category.val()
+			);
+		},
+		makeApiURL = function () {
+			var lang = $from.val();
+
+			return lang ?
+				'https://' +
+					lang + '.wiktionary.org/w/api.php' :
+				null;
+		},
+		onChange = function () {
+			$submit.prop( 'disabled', isValid() );
+			$category.prop( 'disabled', !$from.val() );
+		},
+		fetchCategories = function ( value ) {
+			var url = makeApiURL();
+
+			if ( !url ) {
+				return $.Deferred().reject( [] );
+			}
+
+			return $.ajax(
+				{
+					url: makeApiURL(),
+					dataType: "jsonp",
+					data: {
+						action: 'query',
+						format: 'json',
+						list: 'prefixsearch',
+						pssearch: value,
+						psnamespace: 14, // Category:
+						pslimit: 10
+					}
+				}
+			)
+			.then( function ( result ) {
+				return ( result.query && result.query.prefixsearch ) || [];
+			} )
+			.then( function ( pages ) {
+				return pages
+					.map( function ( page ) {
+						var title = page.title || '',
+							// Hack; remove anything up to the first :
+							// that's the namespace, in any language
+							category = title.substring( title.indexOf( ':' ) + 1 );
+
+						return category;
+					} );
+			} );
+		};
+
+	// Events
+	$from.on( 'change keydown', onChange );
+	$to.on( 'change keydown', onChange );
+	$category.autocomplete( {
+		source: function ( request, response ) {
+			fetchCategories( $category.val() )
+				.then( function ( results ) {
+					response( results );
+				} )
+		}
+	} );
+
+	// Initialize
+	$submit.prop( 'disabled', !isValid() );
+	$category.prop( 'disabled', !$from.val() );
+} );

--- a/header.php
+++ b/header.php
@@ -10,9 +10,12 @@
 <script src="https://tools.wmflabs.org/wdvd/https.js"></script>
 
 <link rel="stylesheet" type="text/css" href="//tools.wmflabs.org/dexbot/tools/semantic/dist/semantic.min.css">
+<link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
 <script src="//tools.wmflabs.org/dexbot/tools/jquery.min.js"></script>
 <script src="//tools.wmflabs.org/dexbot/tools/semantic/tablesort.min.js"></script>
 <script src="//tools.wmflabs.org/dexbot/tools/semantic/dist/semantic.min.js"></script>
+<script src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+<script src="enhancement.js"></script>
 </head>
 <body>
   <div class="main nav">

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@ require_once( 'header.php' );
 error_reporting(E_ERROR|E_CORE_ERROR|E_COMPILE_ERROR); // E_ALL|
 ini_set('display_errors', 'On');
 
-$fromLang = isset( $_REQUEST['fromLang'] ) ? $_REQUEST['fromLang'] : '';
+$fromLang = isset( $_REQUEST['fromLang'] ) ? $_REQUEST['fromLang'] : 'en';
 $toLang = isset( $_REQUEST['toLang'] ) ? $_REQUEST['toLang'] : '';
 $category = isset( $_REQUEST['category'] ) ? $_REQUEST['category'] : '';
 if (isset($_REQUEST['limit']) && $_REQUEST['limit']) {


### PR DESCRIPTION
- Enable/disable the button for when it's valid to prevent sending
  requests when fields are empty.
- Add jquery-ui (for simplicity) autocomplete plugin to categories input
  and fetch from wiktionary API based on the "from" language that's
  used; show suggested categories based on search term.